### PR TITLE
Add support for relative snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,15 +116,8 @@ than at the base working directory.
 Set to a string to name your snapshot something other than 'snapshots.js'
 
 #### Usage
-To set a configuration, pass it as an arg to the `.regsiter()` call:
-```js
-var config = {
-  snapshotFileName: 'cypress-snapshots.js',
-  useRelativeSnapshots: true
-}
-  
-require("@cypress/snapshot").register(config);
-```
+Set the configuration options as part of the Cypress config.
+See https://docs.cypress.io/guides/references/configuration.html
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ describe('focused input field', () => {
 })
 ```
 
-The snapshot object can be found in file `snapshots.js`. In the above case it would look something like this
+By default, the snapshot object can be found in file `snapshots.js`. In the above case it would look something like this
 
 ```js
 module.exports = {
@@ -100,6 +100,30 @@ cy.get(...).snapshot({
   json: false                  // convert DOM elements into JSON
                                // when storing in the snapshot file
 })
+```
+
+### Configuration
+
+This module provides some configuration options:
+
+#### useRelativeSnapshots
+Set to true in order to store your snapshots for each test run next to the inital test caller rather
+than at the base working directory.
+
+**Note:** requires the `readFileMaybe` plugin to be configured see https://on.cypress.io/task#Read-a-file-that-might-not-exist
+
+#### snapshotFileName
+Set to a string to name your snapshot something other than 'snapshots.js'
+
+#### Usage
+To set a configuration, pass it as an arg to the `.regsiter()` call:
+```js
+var config = {
+  snapshotFileName: 'cypress-snapshots.js',
+  useRelativeSnapshots: true
+}
+  
+require("@cypress/snapshot").register(config);
 ```
 
 ## Debugging

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
       ],
       "pre-push": [
         "npm run unused-deps",
-        "npm run secure",
         "npm run license",
         "npm run ban -- --all",
         "npm run size"
@@ -58,7 +57,6 @@
     "license": "license-checker --production --onlyunknown --csv",
     "lint": "eslint --fix src/*.js",
     "pretest": "npm run lint",
-    "secure": "nsp check",
     "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";",
     "test": "npm run unit",
     "unit": "mocha src/*-spec.js",
@@ -84,7 +82,6 @@
     "github-post-release": "1.13.1",
     "license-checker": "15.0.0",
     "mocha": "4.0.1",
-    "nsp": "3.1.0",
     "pre-git": "3.16.0",
     "semantic-release": "^8.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "its-name": "1.0.0",
     "js-beautify": "1.7.5",
     "lazy-ass": "1.6.0",
+    "path": "0.12.7",
     "snap-shot-compare": "2.7.1",
     "snap-shot-store": "1.2.3"
   }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "its-name": "1.0.0",
     "js-beautify": "1.7.5",
     "lazy-ass": "1.6.0",
-    "path": "0.12.7",
     "snap-shot-compare": "2.7.1",
     "snap-shot-store": "1.2.3"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const {
   countSnapshots
 } = require('./utils')
 
-const DEFAULT_CONFIG = {
+const DEFAULT_CONFIG_OPTIONS = {
   // using relative snapshots requires a simple
   // 'readFileMaybe' plugin to be configured
   // see https://on.cypress.io/task#Read-a-file-that-might-not-exist
@@ -31,12 +31,16 @@ function compareValues ({ expected, value }) {
   return compare({ expected, value, noColor, json })
 }
 
-function registerCypressSnapshot (config) {
+function registerCypressSnapshot () {
   la(is.fn(global.before), 'missing global before function')
   la(is.fn(global.after), 'missing global after function')
   la(is.object(global.Cypress), 'missing Cypress object')
 
-  config = Object.assign(DEFAULT_CONFIG, config)
+  const useRelative = Cypress.config("useRelativeSnapshots");
+  config = {
+    useRelativeSnapshots: useRelative === undefined ? DEFAULT_CONFIG_OPTIONS.useRelativeSnapshots : useRelative,
+    snapshotFileName: Cypress.config("snapshotFileName") || DEFAULT_CONFIG_OPTIONS.snapshotFileName
+  }
 
   console.log('registering @cypress/snapshot')
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,8 @@ function registerCypressSnapshot () {
   la(is.fn(global.after), 'missing global after function')
   la(is.object(global.Cypress), 'missing Cypress object')
 
-  const useRelative = Cypress.config("useRelativeSnapshots");
-  config = {
+  const useRelative = Cypress.config("useRelativeSnapshots")
+  const config = {
     useRelativeSnapshots: useRelative === undefined ? DEFAULT_CONFIG_OPTIONS.useRelativeSnapshots : useRelative,
     snapshotFileName: Cypress.config("snapshotFileName") || DEFAULT_CONFIG_OPTIONS.snapshotFileName
   }


### PR DESCRIPTION
## Description
Adds some configuration options to the register call to allow consumers to specify a different name for snapshots and to store snapshots next to their tests instead of in the base directory.

### Example
cypress.json
```js
{
  snapshotFileName: 'cypress-snapshots.js',
  useRelativeSnapshots: true
}
```

### Removing NSP
Also removes the `nsp check` pre-push hook as nsp has been deprecated: https://blog.npmjs.org/post/175511531085/the-node-security-platform-service-is-shutting?_ga=2.86111704.173770583.1554322814-927454317.1554322814

It was also causing the push to fail on my Windows machine.