### PR TITLE
fix: snapshot all top level siblings of passed JQuery subjects

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,16 +3,26 @@ const beautify = require('js-beautify').html
 
 // converts DOM element to a JSON object
 function serializeDomElement ($el) {
-  // console.log('snapshot value!', $el)
-  const json = sd.toJSON($el[0])
-  // console.log('as json', json)
+  let serialized = []
 
-  // hmm, why is value not serialized?
-  if ($el.context.value && !json.attributes.value) {
-    json.attributes.value = $el.context.value
+  $el.each(function (index, element) {
+    // console.log('snapshot value!', $el)
+    const json = sd.toJSON(element)
+    // console.log('as json', json)
+
+    // hmm, why is value not serialized?
+    if ($el.context.value && !json.attributes.value) {
+      json.attributes.value = $el.context.value
+    }
+
+    serialized.push(deleteReactIdFromJson(json))
+  })
+
+  if (serialized.length === 1) {
+    return serialized[0]
+  } else {
+    return serialized
   }
-
-  return deleteReactIdFromJson(json)
 }
 
 // remove React id, too transient
@@ -32,8 +42,13 @@ const stripReactIdAttributes = (html) => {
   return html.replace(dataReactId, '')
 }
 
-const serializeReactToHTML = (el$) => {
-  const html = el$[0].outerHTML
+const serializeReactToHTML = ($el) => {
+  let html = ''
+
+  $el.each(function (index, element) {
+    html += element.outerHTML
+  })
+
   const stripped = stripReactIdAttributes(html)
   const options = {
     wrap_line_length: 80,


### PR DESCRIPTION
Fixes issue #23. When serializes DOM or react elements, instead of taking the first element of the passed JQuery object, we iterate through all top level elements and concatonate the serializations. So when serializing this dom:
```html
<p>1</p>
<p>2</p>
<p>3<p>
```

The current JSON output is
```json
"1": {
    "tagName": "p",
    "childNodes": [
      {
        "nodeName": "#text",
        "nodeValue": "1"
      }
    ]
  }
```
and the current HTML output is
```json
"1": "<p>1</p>"
```

Not that the last two `p` tags are missing from the snapshots.

With this fix the JSON output becomes:
```json
"1": [
  {
    "tagName": "p",
    "childNodes": [
      {
        "nodeName": "#text",
        "nodeValue": "1"
      }
    ]
  },
  {
    "tagName": "p",
    "childNodes": [
      {
        "nodeName": "#text",
        "nodeValue": "2"
      }
    ]
  },
  {
    "tagName": "p",
    "childNodes": [
      {
        "nodeName": "#text",
        "nodeValue": "3"
      }
    ]
  }
]
```
and the HTML output:
```json
"1": "<p>1</p><p>2</p><p>3</p>"
```