### PR TITLE
feat(log): Add instructions about updating snapshot to error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ function registerCypressSnapshot () {
         devToolsLog.expected = expected
         delete devToolsLog.value
         devToolsLog.value = value
-        throw new Error(`Snapshot difference\n${json.message}`)
+        throw new Error(`Snapshot difference. To update, delete snapshot and rerun test.\n${json.message}`)
       })
     }
 


### PR DESCRIPTION
Adding a small extra bit of comment to the default snapshot error so users know that deleting the snapshot will update it on the next test run.