### PR TITLE
If snapshot does not exist, return cy.wrap('') to allow .then() chaining

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,8 @@ function registerCypressSnapshot () {
       .task('readFileMaybe', snapshotFileName)
       .then(function (contents) {
         if (!contents) {
-          return cy.writeFile(snapshotFileName, '', 'utf-8', { log: false })
+          cy.writeFile(snapshotFileName, '', 'utf-8', { log: false })
+          return cy.wrap('')
         }
 
         return contents


### PR DESCRIPTION
When using useRelativeSnapshots, there is an error when snapshot does not exist. 

Existing code is effectively
```
cy.writeFile(snapshotFileName, '', 'utf-8', { log: false })
  .then(evaluateLoadedSnapShots)
```
but cypress-io/cypress@ce8f0ee made writeFile return null to conform to other library writers.

Instead of returning result from writeFile, the fix simply does
```
return cy.wrap('')
```
so the .then() works.

This probably solves Issue #122 