### PR TITLE
feat: show snapshot name in error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ describe('focused input field', () => {
     cy.visit('http://todomvc.com/examples/react/')
     cy
       .focused()
-      .snapshot('initial')
+      .snapshot({ name: 'initial' })
       .type('eat healthy breakfast')
-      .snapshot('after typing')
+      .snapshot({ name: 'after typing' })
   })
 })
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ function registerCypressSnapshot () {
         devToolsLog.expected = expected
         delete devToolsLog.value
         devToolsLog.value = value
-        throw new Error(`Snapshot difference. To update, delete snapshot and rerun test.\n${json.message}`)
+        throw new Error(`Snapshot "${name}" difference. To update, delete snapshot and rerun test.\n${json.message}`)
       })
     }
 


### PR DESCRIPTION
I noticed it might be good to show the snapshot name in the error message, especially when making multiple snapshots in one test.

Furthermore there was a typo in the readme. If the name is not passed as object, the snapshot would be saved by index.